### PR TITLE
Support ubuntu 16.04

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -16,6 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const exec = __importStar(require("@actions/exec"));
+const fs = __importStar(require("fs"));
 function intallRbenv(options) {
     return __awaiter(this, void 0, void 0, function* () {
         yield exec.exec('sudo', ['git', 'clone', 'https://github.com/rbenv/rbenv.git', options.rbenvRoot]);
@@ -31,9 +32,19 @@ function installRubyBuild(options) {
             "zlib1g-dev",
             "libncurses5-dev",
             "libffi-dev",
-            "libgdbm5",
             "libgdbm-dev"
         ];
+        const osRelease = fs.readFileSync("/etc/os-release", { encoding: "utf-8" });
+        const matched = osRelease.match(/VERSION_ID="([0-9.]+)"/);
+        const ubuntuVersion = matched ? matched[1] : "0";
+        if (parseFloat(ubuntuVersion) >= 18.04) {
+            // Ubuntu 18.04+ (bionic)
+            packages.push("libgdbm5");
+        }
+        else {
+            // Ubuntu 16.04 (xenial)
+            packages.push("libgdbm3");
+        }
         const rubyBuildInstallPath = `${options.rbenvRoot}/plugins/ruby-build`;
         yield exec.exec('sudo', ['apt-get', 'update']);
         yield exec.exec('sudo', ['apt-get', 'install', '-y', ...packages]);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,5 @@
 import * as exec from '@actions/exec';
+import * as fs from 'fs'
 
 export async function intallRbenv(options: RbenvOptions) {
   await exec.exec('sudo', ['git', 'clone', 'https://github.com/rbenv/rbenv.git', options.rbenvRoot]);
@@ -16,9 +17,20 @@ export async function installRubyBuild(options: RbenvOptions) {
     "zlib1g-dev",
     "libncurses5-dev",
     "libffi-dev",
-    "libgdbm5",
     "libgdbm-dev"
   ];
+
+  const osRelease = fs.readFileSync("/etc/os-release", {encoding: "utf-8"});
+  const matched = osRelease.match(/VERSION_ID="([0-9.]+)"/);
+  const ubuntuVersion = matched ? matched[1] : "0";
+
+  if (parseFloat(ubuntuVersion) >= 18.04 ){
+    // Ubuntu 18.04+ (bionic)
+    packages.push("libgdbm5");
+  } else {
+    // Ubuntu 16.04 (xenial)
+    packages.push("libgdbm3");
+  }
 
   const rubyBuildInstallPath = `${options.rbenvRoot}/plugins/ruby-build`;
 


### PR DESCRIPTION
# Context
I want to use `setup-rbenv` on `ubuntu-16.04`, but error in `setup-rbenv`

So I fixed.

This patch works on my PR (with `sue445/setup-rbenv`)

* https://github.com/sue445/rubicure/runs/369224794
* https://github.com/sue445/rubicure/pull/216

# Detail
## Example
```yaml
jobs:
  test:
    runs-on: ubuntu-16.04

    steps:
      - name: Set up rbenv
        uses: masa-iwasaki/setup-rbenv@v1
```

## Error log
```bash
sudo apt-get install -y libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libgdbm5
```
https://github.com/sue445/rubicure/runs/369098666

