### PR TITLE
Limit Git clone depth

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -2,7 +2,7 @@ import * as exec from '@actions/exec';
 import * as fs from 'fs'
 
 export async function intallRbenv(options: RbenvOptions) {
-  await exec.exec('sudo', ['git', 'clone', 'https://github.com/rbenv/rbenv.git', options.rbenvRoot]);
+  await exec.exec('sudo', ['git', 'clone', '--depth', '1', 'https://github.com/rbenv/rbenv.git', options.rbenvRoot]);
 }
 
 export interface RbenvOptions {
@@ -37,7 +37,7 @@ export async function installRubyBuild(options: RbenvOptions) {
   await exec.exec('sudo', ['apt-get', 'update']);
   await exec.exec('sudo', ['apt-get', 'install', '-y', ...packages]);
 
-  await exec.exec('sudo', ['git', 'clone', 'https://github.com/rbenv/ruby-build.git', rubyBuildInstallPath]);
+  await exec.exec('sudo', ['git', 'clone', '--depth', '1', 'https://github.com/rbenv/ruby-build.git', rubyBuildInstallPath]);
 
   await exec.exec('sudo', ['chown', '-R', options.rbenvRootOwner, options.rbenvRoot])
 };


### PR DESCRIPTION
Improve performance when installing `rbenv` and `ruby-build` by limiting the Git clone depth to the latest commit.

Ref: [git clone --depth](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt)